### PR TITLE
🔧 chore(ai-den)(systemd): refactor systemd-services into dedicated mo…

### DIFF
--- a/modules/parts/home.nix
+++ b/modules/parts/home.nix
@@ -25,8 +25,6 @@
         settings.experimental-features = ["nix-command" "flakes"];
       };
 
-      programs.systemd-services.enable = lib.mkDefault true;
-
       # The home.packages option allows you to install Nix packages into your
       # environment.
       home.packages = [

--- a/modules/parts/hosts/almagest.nix
+++ b/modules/parts/hosts/almagest.nix
@@ -1,5 +1,6 @@
 {
   flake.modules.homeManager.almagest = {
+    inputs,
     pkgs,
     lib,
     username,
@@ -7,6 +8,10 @@
   }: let
     mv_path = "/home/${username}/workspace/MediaViewerProd";
   in {
+    imports = [
+      inputs.self.modules.homeManager.systemd-services
+    ];
+
     home.packages = [
       pkgs.docker-compose
     ];

--- a/modules/parts/hosts/jupiter.nix
+++ b/modules/parts/hosts/jupiter.nix
@@ -9,6 +9,7 @@
   in {
     imports = [
       inputs.self.modules.homeManager.distributedBuilds
+      inputs.self.modules.homeManager.systemd-services
     ];
 
     home.packages = [

--- a/modules/parts/hosts/mars/mars.nix
+++ b/modules/parts/hosts/mars/mars.nix
@@ -15,6 +15,7 @@
         dev
         distributedBuilds
         wallpapers
+        systemd-services
       ];
 
       programs.git.settings.user.email = "kyokley@mars";

--- a/modules/parts/hosts/mercury/mercury.nix
+++ b/modules/parts/hosts/mercury/mercury.nix
@@ -12,6 +12,7 @@
       imports = with inputs.self.modules.homeManager; [
         opencode
         wallpapers
+        systemd-services
       ];
 
       programs.git.settings.user.email = "kyokley@mercury";

--- a/modules/parts/hosts/singularity.nix
+++ b/modules/parts/hosts/singularity.nix
@@ -1,5 +1,9 @@
 {
-  flake.modules.homeManager.singularity = {
+  flake.modules.homeManager.singularity = {inputs, ...}: {
+    imports = [
+      inputs.self.modules.homeManager.systemd-services
+    ];
+
     programs.git.settings.user.email = "kyokley@singularity";
 
     home.stateVersion = "23.11"; # Please read the comment before changing.

--- a/modules/parts/hosts/venus.nix
+++ b/modules/parts/hosts/venus.nix
@@ -1,5 +1,13 @@
 {
-  flake.modules.homeManager.venus = {pkgs, ...}: {
+  flake.modules.homeManager.venus = {
+    inputs,
+    pkgs,
+    ...
+  }: {
+    imports = [
+      inputs.self.modules.homeManager.systemd-services
+    ];
+
     programs = {
       git.settings.user.email = "kyokley@venus";
       zsh = {

--- a/modules/parts/systemd.nix
+++ b/modules/parts/systemd.nix
@@ -1,56 +1,44 @@
-{inputs, ...}: {
+{
   flake.modules = {
-    homeManager.common = {
+    homeManager.systemd-services = {
       config,
       lib,
       pkgs,
       ...
-    }: let
-      cfg = config.programs.systemd-services;
-    in {
-      options.programs.systemd-services = {
-        enable = lib.mkEnableOption "systemd-services";
-      };
-
-      config = lib.mkMerge [
-        (
-          lib.mkIf cfg.enable {
-            systemd.user = {
-              startServices = true;
-              services = {
-                nix-gc = {
-                  Unit.Description = "Run nix gc";
-                  Service = {
-                    Type = "oneshot";
-                    ExecStart = toString (
-                      pkgs.writeShellScript "nix-gc-script" ''
-                        nix-collect-garbage --delete-older-than 7d
-                        ${pkgs.nix}/bin/nix store gc
-                      ''
-                    );
-                  };
-                };
-              };
-
-              timers = {
-                nix-gc = {
-                  Unit = {
-                    Description = "Run nix gc";
-                    After = ["network.target"];
-                  };
-                  Timer = {
-                    OnCalendar = "monthly";
-                    RandomizedDelaySec = 14400;
-                    Persistent = true;
-                    Unit = "nix-gc.service";
-                  };
-                  Install.WantedBy = ["timers.target"];
-                };
-              };
+    }: {
+      systemd.user = {
+        startServices = true;
+        services = {
+          nix-gc = {
+            Unit.Description = "Run nix gc";
+            Service = {
+              Type = "oneshot";
+              ExecStart = toString (
+                pkgs.writeShellScript "nix-gc-script" ''
+                  nix-collect-garbage --delete-older-than 7d
+                  ${pkgs.nix}/bin/nix store gc
+                ''
+              );
             };
-          }
-        )
-      ];
+          };
+        };
+
+        timers = {
+          nix-gc = {
+            Unit = {
+              Description = "Run nix gc";
+              After = ["network.target"];
+            };
+            Timer = {
+              OnCalendar = "monthly";
+              RandomizedDelaySec = 14400;
+              Persistent = true;
+              Unit = "nix-gc.service";
+            };
+            Install.WantedBy = ["timers.target"];
+          };
+        };
+      };
     };
   };
 }


### PR DESCRIPTION
…dule

- extract systemd-services from common module into standalone reusable module
- remove conditional enable option and always-on configuration
- update home.nix to remove default systemd-services setting
- add systemd-services imports to almagest, jupiter, mars, mercury, singularity, and venus host configurations
- simplify module structure by removing unnecessary mkMerge and mkIf wrappers